### PR TITLE
Add tests for job creation handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,8 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorm.io/driver/mysql v1.5.6 // indirect
-	gorm.io/driver/postgres v1.6.0 // indirect
+        gorm.io/driver/mysql v1.5.6 // indirect
+        gorm.io/driver/sqlite v1.5.6 // indirect
+        gorm.io/driver/postgres v1.6.0 // indirect
 	gorm.io/gorm v1.30.0 // indirect
 )

--- a/internal/api/job.go
+++ b/internal/api/job.go
@@ -1,7 +1,50 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+
+	"github.com/hsrkatu17/taskqueue/internal/model"
+)
+
+// CreateJobRequest represents the expected payload for creating a job.
+type CreateJobRequest struct {
+	TenantID uuid.UUID      `json:"tenant_id" binding:"required"`
+	Type     model.JobType  `json:"type" binding:"required"`
+	Payload  datatypes.JSON `json:"payload" binding:"required"`
+}
+
+// CreateJobHandle stores a new job in the database.
 func CreateJobHandle(c *gin.Context) {
+	var req CreateJobRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
+	db, ok := c.MustGet("db").(*gorm.DB)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not available"})
+		return
+	}
+
+	job := model.Job{
+		TenantID:  req.TenantID,
+		Type:      req.Type,
+		Payload:   req.Payload,
+		Status:    model.StatusPending,
+		VisibleAt: time.Now(),
+	}
+
+	if err := db.Create(&job).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, job)
 }

--- a/internal/api/job_test.go
+++ b/internal/api/job_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/hsrkatu17/taskqueue/internal/model"
+)
+
+// setupRouter initializes a Gin engine with an in-memory SQLite DB for testing.
+func setupRouter(t *testing.T) (*gin.Engine, *gorm.DB) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Job{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("db", db)
+		c.Next()
+	})
+	r.POST("/jobs", CreateJobHandle)
+	return r, db
+}
+
+func TestCreateJobHandle_Success(t *testing.T) {
+	router, db := setupRouter(t)
+
+	payload := map[string]any{"foo": "bar"}
+	body, _ := json.Marshal(gin.H{
+		"tenant_id": uuid.New(),
+		"type":      model.JobTypeSendEmail,
+		"payload":   payload,
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, "/jobs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+
+	// ensure job stored in DB
+	var count int64
+	if err := db.Model(&model.Job{}).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count jobs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 job in db, got %d", count)
+	}
+}
+
+func TestCreateJobHandle_BadRequest(t *testing.T) {
+	router, _ := setupRouter(t)
+
+	// Missing type and payload fields
+	body, _ := json.Marshal(gin.H{"tenant_id": uuid.New()})
+	req, _ := http.NewRequest(http.MethodPost, "/jobs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- implement test setup helper and write job creation tests
- add sqlite driver for tests

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fd992ed8c8328bc947ae5f96065a1